### PR TITLE
Refactors LookupServiceRegistryMCPTool to solve async bug with MCPClient

### DIFF
--- a/core/foundation/base_server.py
+++ b/core/foundation/base_server.py
@@ -34,10 +34,14 @@ class BaseServer:
             name="get_capabilities")
         async def get_capabilities() -> dict:
             capabilities = {"tools": {}, "resources": {}, "prompts": {}}
+            print("I am generating capabilities... for tools: ", self._tools)
             for tool in self._tools:
+                print("Tool: ", tool.__class__.__name__, await tool.get_capabilities())
                 capabilities["tools"][tool.__class__.__name__] = await tool.get_capabilities()
+                print(" Done with tool: ", tool.__class__.__name__)
 
             # TODO: Add resources and prompts capabilities
+            print("I generated capabilities: ", capabilities)
             return capabilities
 
     @start_servers()

--- a/core/foundation/look_up_service_registry.py
+++ b/core/foundation/look_up_service_registry.py
@@ -1,9 +1,10 @@
+import asyncio
+
 from mcp.server import FastMCP
 from python_a2a import agent, skill
 
 from core.foundation.models.tools_model import ToolsModel
 from core.foundation.tools import A2ATool, LookupServiceRegistry, MCPTool
-
 
 @agent(
     name="LookupServiceRegistry Tool",
@@ -11,18 +12,15 @@ from core.foundation.tools import A2ATool, LookupServiceRegistry, MCPTool
     description="A tool to look up and interact with a service registry for discovering available tools, resources and prompts. This tool allows clients and agents to query the registry, retrieve tool details, and register new services.",
     tags=["tool", "service", "registry", "lookup", "discovery"],)
 class LookupServiceRegistryMCPTool(A2ATool, MCPTool, LookupServiceRegistry):
-
     def __init__(self, mcp_server: FastMCP , registry_url: str):
         MCPTool.__init__(self, mcp_server)
         A2ATool.__init__(self, mcp_server=mcp_server)
         LookupServiceRegistry.__init__(self, mcp_server, registry_url)
-        LookupServiceRegistryMCPTool.connect_client(self)
 
     @skill(
         name="look_up_service",
         description="Retrieve a tool's/resource's/prompt's details by its registry id from the service registry.",
-        tags={"tool", "registry", "get", "service", "discovery"},
-    )
+        tags={"tool", "registry", "get", "service", "discovery"},)
     async def look_up_service_skill(self, registry_id: str) -> ToolsModel | None:
         return await self.lookup_service(registry_id)
 
@@ -57,42 +55,43 @@ class LookupServiceRegistryMCPTool(A2ATool, MCPTool, LookupServiceRegistry):
             "registry_capability": await LookupServiceRegistry._get_capabilities(self)
         }
 
-    def register_tool(self):
-        @MCPTool.get_mcp(self).tool(
-            name=f"{self.tool_mcp_path_prefix}.look_up_service",
-            title="Look for and fetch Tool/Resource/Prompt by Name",
-            description="Retrieve a tool's details by its registry id from the service registry.",
-            tags={"tool", "registry", "get", "service", "discovery"},
-            output_schema=ToolsModel.model_json_schema(),
-        )
-        async def look_up_service(registry_id: str) -> ToolsModel| None:
-            return await self.lookup_service(registry_id)
 
-        @MCPTool.get_mcp(self).tool(
-            name=f"{self.tool_mcp_path_prefix}.list_service",
-            title="List Registered Tool/Resource/Prompt",
-            description="List all tools currently registered in the service registry.",
-            tags={"tool", "registry", "list", "service", "discovery"},
-        )
-        async def list_services() -> dict[str, ToolsModel] | None:
-            return await self.list_services()
+    def register_tool(self) -> None:
+            @MCPTool.get_mcp(self).tool(
+                name=f"{self.tool_mcp_path_prefix}.look_up_service",
+                title="Look for and fetch Tool/Resource/Prompt by Name",
+                description="Retrieve a tool's details by its registry id from the service registry.",
+                tags={"tool", "registry", "get", "service", "discovery"},
+                output_schema=ToolsModel.model_json_schema(),
+            )
+            async def look_up_service(registry_id: str) -> ToolsModel| None:
+                return await self.lookup_service(registry_id)
 
-        @MCPTool.get_mcp(self).tool(
-            name=f"{self.tool_mcp_path_prefix}.register_service",
-            title="Add Tool/Resource/Prompt to Registry",
-            description="Add a new tool to the service registry.",
-            tags={"tool", "registry", "add", "service", "discovery"},
-            output_schema=None,
-        )
-        async def register_service(service: ToolsModel) -> None:
-            await self.register_service(service)
+            @MCPTool.get_mcp(self).tool(
+                name=f"{self.tool_mcp_path_prefix}.list_service",
+                title="List Registered Tool/Resource/Prompt",
+                description="List all tools currently registered in the service registry.",
+                tags={"tool", "registry", "list", "service", "discovery"},
+            )
+            async def list_services() -> dict[str, ToolsModel] | None:
+                return await self.list_services()
 
-        @MCPTool.get_mcp(self).tool(
-            name=f"{self.tool_mcp_path_prefix}.get_capabilities",
-            title="Get Capabilities",
-            description="Get the capabilities of the Service Registry tool.",
-            tags={"tool", "capabilities", "info"},
-        )
-        async def get_capabilities() -> dict:
-            return await self._get_capabilities()
+            @MCPTool.get_mcp(self).tool(
+                name=f"{self.tool_mcp_path_prefix}.register_service",
+                title="Add Tool/Resource/Prompt to Registry",
+                description="Add a new tool to the service registry.",
+                tags={"tool", "registry", "add", "service", "discovery"},
+                output_schema=None,
+            )
+            async def register_service(service: ToolsModel) -> None:
+                await self.register_service(service)
+
+            @MCPTool.get_mcp(self).tool(
+                name=f"{self.tool_mcp_path_prefix}.get_capabilities",
+                title="Get Capabilities",
+                description="Get the capabilities of the Service Registry tool.",
+                tags={"tool", "capabilities", "info"},
+            )
+            async def get_capabilities() -> dict:
+                return await self._get_capabilities()
 

--- a/core/foundation/tools.py
+++ b/core/foundation/tools.py
@@ -1,6 +1,9 @@
+import asyncio
 from abc import ABC, abstractmethod
+from contextlib import asynccontextmanager
 
-from fastmcp import FastMCP
+from fastmcp import FastMCP, Client
+from fastmcp.client import StreamableHttpTransport
 from python_a2a import A2AServer, run_server
 
 from client.client import MyClient
@@ -49,6 +52,9 @@ class A2ATool(A2AServer, ABC):
     async def _get_capabilities(self) -> dict:
         return  self.agent_card.to_dict()
 
+    async def get_capabilities(self) -> dict:
+        return await self._get_capabilities()
+
     @continuous_process
     def run(self, host: str, port: int, **kwargs):
         self.agent_card.url = f"http://{host}:{port}"
@@ -60,31 +66,41 @@ class LookupServiceRegistry:
     def __init__(self, mcp_server: FastMCP, registry_url: str):
         self.mcp = mcp_server
         self._registry_url: str = registry_url
-        self.client = MyClient(self._registry_url)
 
+    @asynccontextmanager
+    async def _client(self):
+        async with Client(StreamableHttpTransport(url=self._registry_url)) as c:
+            yield c
 
     async def _get_capabilities(self) -> dict:
-        capability = await self.client.call_tool(f"service_registry.get_capabilities")
-        return capability.structured_content
+        async with self._client() as client:
+            capability = await client.call_tool(f"service_registry.get_capabilities")
+            return capability.structured_content
 
-    async def connect_client(self):
-        await self.client.connect()
+    async def get_capabilities(self) -> dict:
+        return await self._get_capabilities()
+
+    # async def connect_client(self):
+    #     await self.client.connect()
 
     async def lookup_service(self, registry_id: str) -> ToolsModel | None:
-        result = await self.client.call_tool(f"service_registry.get_tool",
-                                             registry_id= registry_id)
-        return ToolsModel.model_validate(result.structured_content)
+        async with self._client() as client:
+            result = await client.call_tool("service_registry.get_tool",
+                                            arguments={"registry_id": registry_id})
+            return ToolsModel.model_validate(result.structured_content)
 
     async def register_service(self, service: ToolsModel) -> None:
-        await self.client.call_tool(f"service_registry.add_tool_to_registry",
-                                    tool = service.model_dump())
+        async with self._client() as client:
+            client.call_tool(f"service_registry.add_tool_to_registry",
+                             arguments={"tool": service.model_dump()})
 
     async def list_services(self) -> dict[str, ToolsModel] | None:
-        result = await self.client.call_tool(f"service_registry.list_tools")
-        print("This is raw result from list_services:", result)
-        tools = {}
-        for reg_id, item in result.structured_content.items():
-            tools[reg_id] = ToolsModel.model_validate(item).model_dump()
-        print("Parsed tools:", tools)
-        return tools
+        async with self._client() as client:
+            result = await client.call_tool(f"service_registry.list_tools")
+            print("This is raw result from list_services:", result)
+            tools = {}
+            for reg_id, item in result.structured_content.items():
+                tools[reg_id] = ToolsModel.model_validate(item).model_dump()
+            print("Parsed tools:", tools)
+            return tools
 

--- a/core/utils/run_blocking.py
+++ b/core/utils/run_blocking.py
@@ -1,0 +1,11 @@
+import asyncio
+
+
+def run_blocking(coro):
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(coro)
+    else:
+        # loop is running; fire-and-forget or await elsewhere
+        return asyncio.create_task(coro)

--- a/tools/routers/assign_author.py
+++ b/tools/routers/assign_author.py
@@ -39,6 +39,12 @@ class AssignAuthor(A2ATool, MCPTool):
         MCPTool.__init__(self, mcp_server)
         self._llm_client = LocalLMClient()
 
+    async def get_capabilities(self) -> dict:
+        return {
+            "mcp_capability": await MCPTool._get_capabilities(self),
+            "a2a_capability": await A2ATool._get_capabilities(self),
+        }
+
     def register_tool(self) -> None:
         """
         Register the assign_author tool with the MCP server.
@@ -80,4 +86,4 @@ class AssignAuthor(A2ATool, MCPTool):
             description="Get the capabilities of the AssignAuthor tool.",
         )
         async def get_capabilities() -> dict:
-            return await self._get_capabilities()
+            return await self.get_capabilities()


### PR DESCRIPTION
Refactor `LookupServiceRegistryMCPTool` by introducing async contexts to manage client connections more elegantly. This includes updating tool registration methods to utilize the new context manager pattern. Additionally, enhance logging within the `get_capabilities` method for better traceability.

Added background runner for blocking tasks

Relates to improving code maintainability and debugging capabilities.
